### PR TITLE
itest: extend HTLC quiesce assertions to all route nodes

### DIFF
--- a/itest/custom_channels/liquidity_test.go
+++ b/itest/custom_channels/liquidity_test.go
@@ -479,11 +479,8 @@ func testCustomChannelsLiquidityEdgeCasesCore(ctx context.Context,
 	)
 	require.NoError(t.t, err)
 
-	// There should be no HTLCs present on any channel.
-	assertNumHtlcs(t.t, charlie, 0)
-	assertNumHtlcs(t.t, dave, 0)
-	assertNumHtlcs(t.t, erin, 0)
-	assertNumHtlcs(t.t, fabia, 0)
+	// Wait for the full route to quiesce.
+	assertNumHtlcsAll(t.t, 0, charlie, dave, erin, fabia)
 
 	// Now Fabia creates another invoice. We also use a fixed msat value for
 	// the invoice. Since our itest oracle evaluates every asset to about
@@ -581,7 +578,8 @@ func testCustomChannelsLiquidityEdgeCasesCore(ctx context.Context,
 	)
 	require.NoError(t.t, err)
 
-	assertNumHtlcs(t.t, dave, 0)
+	// Wait for the full route to quiesce before moving on.
+	assertNumHtlcsAll(t.t, 0, erin, dave, charlie)
 
 	logBalance(t.t, nodes, assetID, "after small manual rfq")
 

--- a/itest/custom_channels/multi_rfq_test.go
+++ b/itest/custom_channels/multi_rfq_test.go
@@ -144,9 +144,11 @@ func testCustomChannelsMultiRFQ(_ context.Context,
 	)
 	require.NoError(t.t, err)
 
-	assertNumHtlcs(t.t, dave, 0)
-	assertNumHtlcs(t.t, erin, 0)
-	assertNumHtlcs(t.t, yara, 0)
+	// Wait for the full route to quiesce before attempting the next
+	// payment.
+	assertNumHtlcsAll(
+		t.t, 0, charlie, dave, erin, fabia, yara, george,
+	)
 
 	logBalance(t.t, nodes, assetID, "after cancelled hodl")
 
@@ -207,8 +209,11 @@ func testCustomChannelsMultiRFQ(_ context.Context,
 	)
 	require.NoError(t.t, err)
 
-	assertNumHtlcs(t.t, charlie, 0)
-	assertNumHtlcs(t.t, fabia, 0)
+	// Wait for the full route to quiesce before attempting the next
+	// payment.
+	assertNumHtlcsAll(
+		t.t, 0, charlie, dave, erin, fabia, yara, george,
+	)
 
 	logBalance(t.t, nodes, assetID, "after multi-rfq send")
 


### PR DESCRIPTION
Applies the same assertNumHtlcsAll pattern from the liquidity cleanup deflake to the remaining cases that were only checking a subset of route nodes before the next payment:

- multi_rfq_test.go: check all 6 nodes (charlie, dave, erin, fabia, yara, george) after hodl cancel and after hodl settle
- liquidity_test.go: check all 3 route nodes (erin, dave, charlie) after the small manual rfq cancel, and convert the existing 4-node check to use assertNumHtlcsAll for consistency